### PR TITLE
Create element instances in insert operations

### DIFF
--- a/gdocrevisions/document.py
+++ b/gdocrevisions/document.py
@@ -25,8 +25,7 @@ class Content(object):
         apply a revision to content, by applying all of its operations
         """
         for operation in revision.operations:
-            # revision is passed so that content elements can reference revision
-            operation.apply(self.elements, revision)
+            operation.apply(self.elements)
 
     def apply_revisions(self, revisions):
         for revision in revisions:

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -88,3 +88,24 @@ class MultiOperation(Operation):
         for suboperation in self.suboperations:
             self.suboperation.apply(elements)
 
+    def flatten(self):
+        """
+        Flatten the suboperation tree into a list
+        """
+        return flatten_multioperation(self)
+
+def flatten_multioperation(operation):
+    """
+    Flattens suboperation tree of a multioperation into a list
+    If input operation is not a multioperation, returns that operation inside a list of size 1
+    Arguments:
+        operation (Operation): Operation (or Operation subclass) instance
+    """
+    operations = []
+    if type(operation) is MultiOperation:
+        for suboperation in operation.suboperations:
+            operations.extend(flatten_multioperation(suboperation))
+    else:
+        operations = [operation]
+    return operations
+

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -24,6 +24,7 @@ class Operation(object):
         operation_raw is a dictionary of raw operation metadata
         """
         self.raw = operation_raw
+        self.type = 'operation'
 
     def apply(self, elements, revision):
         """

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -1,7 +1,7 @@
 from element import Character
 
 
-def getOperation(operation_raw, revision):
+def operation_factory(operation_raw, revision):
     """
     Factory method that returns Operation or subclass instance
     takes as input a single dict with change info
@@ -78,7 +78,7 @@ class MultiOperation(Operation):
     """
     def __init__(self, operation_raw, revision):
         super(MultiOperation, self).__init__(operation_raw, revision)
-        self.suboperations = [getOperation(suboperation_raw, revision) for suboperation_raw in operation_raw['mts']]
+        self.suboperations = [operation_factory(suboperation_raw, revision) for suboperation_raw in operation_raw['mts']]
         self.type = 'multiple operations'
 
     def apply(self, elements):

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -1,6 +1,7 @@
 from element import Character
 
-def getOperation(operation_raw):
+
+def getOperation(operation_raw, revision):
     """
     Factory method that returns Operation or subclass instance
     takes as input a single dict with change info
@@ -11,7 +12,7 @@ def getOperation(operation_raw):
         'mlti': MultiOperation,
     }
     operation = operation_types.get(operation_raw['ty']) or Operation
-    return operation(operation_raw)
+    return operation(operation_raw, revision)
 
 
 class Operation(object):
@@ -19,14 +20,15 @@ class Operation(object):
     Base Operation class
     Represents action(s) that occur as part of a revision
     """
-    def __init__(self, operation_raw):
+    def __init__(self, operation_raw, revision):
         """
         operation_raw is a dictionary of raw operation metadata
         """
         self.raw = operation_raw
         self.type = 'operation'
+        self.revision = revision
 
-    def apply(self, elements, revision):
+    def apply(self, elements):
         """
         elements is a list of Element instances
         """
@@ -37,31 +39,32 @@ class InsertString(Operation):
     """
     Operation subclass representing an "Insert String" operation
     """
-    def __init__(self, operation_raw):
-        super(InsertString, self).__init__(operation_raw)
+    def __init__(self, operation_raw, revision):
+        super(InsertString, self).__init__(operation_raw, revision)
         self.string = operation_raw['s']
         self.start_index = operation_raw['ibi']
         self.type = 'insert string'
+        self.elements = [Character(self.revision, char) for char in self.string]
 
-    def apply(self, elements, revision):
+    def apply(self, elements):
         """
         Insert string into document at specified index
         """
-        for i,char in enumerate(self.string):
-            elements.insert(self.start_index-1+i, Character(revision, char))
+        for i,element in enumerate(self.elements):
+            elements.insert(self.start_index-1+i, element)
 
 
 class DeleteString(Operation):
     """
     Operation subclass representing a "Delete String" operation
     """
-    def __init__(self, operation_raw):
-        super(DeleteString, self).__init__(operation_raw)
+    def __init__(self, operation_raw, revision):
+        super(DeleteString, self).__init__(operation_raw, revision)
         self.start_index = operation_raw['si']
         self.end_index = operation_raw['ei']
         self.type = 'delete string'
 
-    def apply(self, elements, revision):
+    def apply(self, elements):
         """
         Delete string from document between specified indices
         """
@@ -73,15 +76,15 @@ class MultiOperation(Operation):
     Operation subclass representing a "Multiple Operation" operation
     Contains an array of Operation objects
     """
-    def __init__(self, operation_raw):
-        super(MultiOperation, self).__init__(operation_raw)
-        self.suboperations = [getOperation(x) for x in operation_raw['mts']]
+    def __init__(self, operation_raw, revision):
+        super(MultiOperation, self).__init__(operation_raw, revision)
+        self.suboperations = [getOperation(suboperation_raw, revision) for suboperation_raw in operation_raw['mts']]
         self.type = 'multiple operations'
 
-    def apply(self, elements, revision=None):
+    def apply(self, elements):
         """
         Apply each of the suboperations comprising the MultiOperation
         """
         for suboperation in self.suboperations:
-            self.suboperation.apply(elements, revision)
-            
+            self.suboperation.apply(elements)
+

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -34,6 +34,12 @@ class Operation(object):
         """
         pass
 
+    def flatten(self):
+        """
+        Default behavior for flatten returns the operation as the singular element of a list
+        """
+        return [self]
+
 
 class InsertString(Operation):
     """
@@ -92,20 +98,8 @@ class MultiOperation(Operation):
         """
         Flatten the suboperation tree into a list
         """
-        return flatten_multioperation(self)
-
-def flatten_multioperation(operation):
-    """
-    Flattens suboperation tree of a multioperation into a list
-    If input operation is not a multioperation, returns that operation inside a list of size 1
-    Arguments:
-        operation (Operation): Operation (or Operation subclass) instance
-    """
-    operations = []
-    if type(operation) is MultiOperation:
-        for suboperation in operation.suboperations:
-            operations.extend(flatten_multioperation(suboperation))
-    else:
-        operations = [operation]
-    return operations
+        operations = []
+        for suboperation in self.suboperations:
+            operations.extend(suboperation.flatten())
+        return operations
 

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -4,7 +4,10 @@ from element import Character
 def operation_factory(operation_raw, revision):
     """
     Factory method that returns Operation or subclass instance
-    takes as input a single dict with change info
+    Arguments:
+        operation_raw (dict): raw operation data
+        revision (Revision): revision instance, which gets associated
+            with any created Element objects
     """
     operation_types = {
         'is': InsertString,
@@ -96,7 +99,7 @@ class MultiOperation(Operation):
 
     def flatten(self):
         """
-        Flatten the suboperation tree into a list
+        Flatten the suboperation tree into a list of suboperations
         """
         operations = []
         for suboperation in self.suboperations:

--- a/gdocrevisions/revision.py
+++ b/gdocrevisions/revision.py
@@ -9,6 +9,7 @@ class Revision(object):
     https://developers.google.com/drive/v3/reference/revisions
     A Revision contains an Operation
     """
+
     def __init__(self, revision_raw):
         # timestamp
         self.time = datetime.fromtimestamp(revision_raw[1] / 1e3)
@@ -25,12 +26,13 @@ class Revision(object):
         # dictionary of raw operation metadata
         self.operation_raw = revision_raw[0]
         # Operation object
-        self.operation = getOperation(self.operation_raw)
+        self.operation = getOperation(self.operation_raw, self)
         # Array of operations, with no multi operations
         self.operations = _flatten_multioperation(self.operation)
 
+
     def to_dict(self):
-        dict_attributes = [
+        DICT_ATTRIBUTES = [
             'time',
             'user_id',
             'revision_id',
@@ -41,7 +43,8 @@ class Revision(object):
             'operation',
             'operations'
         ]
-        return {attr:getattr(self,attr) for attr in dict_attributes}
+        return {attr:getattr(self,attr) for attr in self.DICT_ATTRIBUTES}
+
 
 def _flatten_multioperation(operation):
     operations = []

--- a/gdocrevisions/revision.py
+++ b/gdocrevisions/revision.py
@@ -28,8 +28,8 @@ class Revision(object):
         # Operation object
         self.operation = operation_factory(self.operation_raw, self)
         # Array of operations, with no multi operations
-        self.operations = _flatten_multioperation(self.operation)
-
+        self.operations = self.operation.flatten() if self.operation.__class__.__name__=='MultiOperation' else [self.operation]
+        
 
     def to_dict(self):
         DICT_ATTRIBUTES = [
@@ -44,15 +44,5 @@ class Revision(object):
             'operations'
         ]
         return {attr:getattr(self,attr) for attr in self.DICT_ATTRIBUTES}
-
-
-def _flatten_multioperation(operation):
-    operations = []
-    if type(operation) is MultiOperation:
-        for suboperation in operation.suboperations:
-            operations.extend(_flatten_multioperation(suboperation))
-    else:
-        operations = [operation]
-    return operations
     
 

--- a/gdocrevisions/revision.py
+++ b/gdocrevisions/revision.py
@@ -1,4 +1,4 @@
-from operation import getOperation, MultiOperation
+from operation import operation_factory, MultiOperation
 from datetime import datetime
 
 
@@ -26,7 +26,7 @@ class Revision(object):
         # dictionary of raw operation metadata
         self.operation_raw = revision_raw[0]
         # Operation object
-        self.operation = getOperation(self.operation_raw, self)
+        self.operation = operation_factory(self.operation_raw, self)
         # Array of operations, with no multi operations
         self.operations = _flatten_multioperation(self.operation)
 

--- a/gdocrevisions/revision.py
+++ b/gdocrevisions/revision.py
@@ -1,4 +1,4 @@
-from operation import operation_factory, MultiOperation
+from operation import operation_factory
 from datetime import datetime
 
 
@@ -28,7 +28,7 @@ class Revision(object):
         # Operation object
         self.operation = operation_factory(self.operation_raw, self)
         # Array of operations, with no multi operations
-        self.operations = self.operation.flatten() if self.operation.__class__.__name__=='MultiOperation' else [self.operation]
+        self.operations = self.operation.flatten()
         
 
     def to_dict(self):


### PR DESCRIPTION
Instead of creating Character instances in the operation instance method `apply()` , Element instance creation now happens on Operation instance initialization. InsertString Operations will have an "elements" attribute containing the list of Character objects to be added, and the apply method insert those elements into content objects. This way, revision info is associated at the character level throughout the entire history without having to replay the document revisions.