### PR TITLE
Introduce suboperations

### DIFF
--- a/gdocrevisions/document.py
+++ b/gdocrevisions/document.py
@@ -23,20 +23,15 @@ class Content(object):
     def __init__(self):
         self.elements = [EndOfBody()]
 
-    def apply_operation(self, operation):
-        operation.apply(self.elements)
-
-    def apply_revision(self, revision):
+    def apply(self, change):
         """
-        apply a revision to content, by applying all of its operations
-        """
-        for operation in revision.operations:
-            self.apply_operation(operation)
+        Apply some change (could be a revision, operation, or suboperation) to the content elements
 
-    def apply_revisions(self, revisions):
-        for revision in revisions:
-            self.apply_revision(revision)
-    
+        Arguments:
+            change (Revision, Operation, or Suboperation): object whoses changes should be applied to the content instance
+        """
+        change.apply(self.elements)
+        
     def render(self):
         return ''.join([element.render() for element in self.elements])
 
@@ -70,7 +65,8 @@ class Document(object):
         # populate content by applying all revisions
         if apply_revisions:
             logger.debug("[Document.__init__()]: Applying revisions")
-            self.content.apply_revisions(self.revisions)
+            for revision in self.revisions:
+                self.content.apply(revision)
         logger.debug("[Document.__init__()]: Finished")
 
     def at_time(self, datetime):
@@ -79,7 +75,7 @@ class Document(object):
         """
         revisions = filter(lambda revision: revision.time<=datetime, self.revisions)
         self.content.reset()
-        self.content.apply_revisions(revisions)
+        self.content.apply(revisions)
         return self
 
     def at_revision(self, revision_id):
@@ -88,7 +84,7 @@ class Document(object):
         """
         revisions = filter(lambda revision: revision.revision_id<=revision_id, self.revisions)
         self.content.reset()
-        self.content.apply_revisions(revisions)
+        self.content.apply(revisions)
         return self
 
     def to_pickle(self, path):
@@ -121,11 +117,11 @@ class Document(object):
         content_state = Content()
         if by == 'operation':
             for revision in self.revisions:
-                content_state.apply_revision(revision)
+                content_state.apply(revision)
                 yield content_state
         elif by == 'revision':
             for operation in self.iter_operations():
-                content_state.apply_operation(operation)
+                content_state.apply(operation)
                 yield content_state
         else:
             raise ValueError("'by' not in accepted values (revision, operation)")

--- a/gdocrevisions/document.py
+++ b/gdocrevisions/document.py
@@ -138,6 +138,14 @@ class Document(object):
             for operation in revision.iter_operations():
                 yield operation
 
+    def iter_suboperations(self):
+        """
+        Generator that iterates over suboperations
+        """
+        for revision in self.revisions:
+            for suboperation in revision.iter_suboperations():
+                yield suboperation
+
     @property
     def operations(self):
         """

--- a/gdocrevisions/element.py
+++ b/gdocrevisions/element.py
@@ -16,7 +16,7 @@ class Character(Element):
 	Character element
 	Represents a single character
 	"""
-	def __init__(self, revision, char):
+	def __init__(self, char, revision):
 		# revision object reference
 		self.revision = revision
 		# character string

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -43,6 +43,10 @@ class Operation(object):
     def iter_operations(self):
         yield self
 
+    def iter_suboperations(self):
+        for suboperation in self.suboperations:
+            yield suboperation
+
     def to_dict(self):
         DICT_ATTRIBUTES = [
             'type',
@@ -102,3 +106,8 @@ class MultiOperation(Operation):
                     yield operation
             else:
                 yield operation
+
+    def iter_suboperations(self):
+        for operation in self.iter_operations():
+            for iter_suboperation in operation.iter_suboperations():
+                yield suboperation

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -109,5 +109,5 @@ class MultiOperation(Operation):
 
     def iter_suboperations(self):
         for operation in self.iter_operations():
-            for iter_suboperation in operation.iter_suboperations():
+            for suboperation in operation.iter_suboperations():
                 yield suboperation

--- a/gdocrevisions/operation.py
+++ b/gdocrevisions/operation.py
@@ -1,4 +1,5 @@
 from element import Character
+from suboperation import InsertElement, DeleteElement
 
 
 def operation_factory(operation_raw, revision):
@@ -30,12 +31,14 @@ class Operation(object):
         self.raw = operation_raw
         self.type = self.__class__.__name__
         self.revision = revision
+        self.suboperations = []
 
     def apply(self, elements):
         """
         elements is a list of Element instances
         """
-        pass
+        for suboperation in self.suboperations:
+            suboperation.apply(elements)
 
     def iter_operations(self):
         yield self
@@ -56,14 +59,8 @@ class InsertString(Operation):
         super(InsertString, self).__init__(operation_raw, revision)
         self.string = operation_raw['s']
         self.start_index = operation_raw['ibi']
-        self.elements = [Character(self.revision, char) for char in self.string]
-
-    def apply(self, elements):
-        """
-        Insert string into document at specified index
-        """
-        for i,element in enumerate(self.elements):
-            elements.insert(self.start_index-1+i, element)
+        # self.elements = [Character(self.revision, char) for char in self.string]
+        self.suboperations = [InsertElement(self.start_index+i, Character(char, self.revision)) for i,char in enumerate(self.string)]
 
 
 class DeleteString(Operation):
@@ -74,13 +71,7 @@ class DeleteString(Operation):
         super(DeleteString, self).__init__(operation_raw, revision)
         self.start_index = operation_raw['si']
         self.end_index = operation_raw['ei']
-
-    def apply(self, elements):
-        """
-        Delete string from document between specified indices
-        """
-        for i in range(self.end_index-self.start_index+1):
-            elements.pop(self.start_index-1)
+        self.suboperations = [DeleteElement(self.end_index-i) for i in range(self.end_index-self.start_index+1)]
 
 
 class MultiOperation(Operation):

--- a/gdocrevisions/revision.py
+++ b/gdocrevisions/revision.py
@@ -29,6 +29,8 @@ class Revision(object):
         self.operation = operation_factory(self.operation_raw, self)
         # Iterator for operations
         self.iter_operations = self.operation.iter_operations
+        # Iterator for suboperations
+        self.iter_suboperations = self.operation.iter_suboperations
         
     @property
     def operations(self):

--- a/gdocrevisions/revision.py
+++ b/gdocrevisions/revision.py
@@ -39,6 +39,15 @@ class Revision(object):
         """
         return list(self.iter_operations())
         
+    def apply(self, elements):
+        """
+        Apply the revision to a list of elements
+
+        Arguments:
+            elements (list): usually the elements attribute of a Content instance
+        """
+        for operation in self.iter_operations():
+            operation.apply(elements)
         
     def to_dict(self):
         DICT_ATTRIBUTES = [

--- a/gdocrevisions/suboperation.py
+++ b/gdocrevisions/suboperation.py
@@ -1,0 +1,49 @@
+from element import Character
+
+class Suboperation(object):
+    """
+    Base Suboperation class
+    Represents action that are associated with single Element
+    """
+    def __init__(self, element):
+        """
+        operation_raw is a dictionary of raw operation metadata
+        """
+        self.element = element
+
+    @property
+    def type(self):
+        return self.__class__.__name__
+
+    def apply(self, elements):
+        """
+        elements is a list of Element instances
+        """
+        pass
+
+
+class InsertElement(Suboperation):
+    """
+    Insert Character Suboperation class
+    """
+    def __init__(self, index, element):
+        self.index = index
+        self.element = element
+
+    def apply(self, elements):
+        elements.insert(self.index-1,self.element)
+
+
+class DeleteElement(Suboperation):
+    """
+    Delete Character Suboperation class
+    """
+    def __init__(self, index):
+        self.index = index
+        # self.element = element
+
+    def apply(self, elements):
+        element = elements.pop(self.index-1)
+
+        # TODO could modify popped element here?
+        # would revision need to be passed in then?


### PR DESCRIPTION
Introduces the Suboperation class. Operations are further split up into multiple suboperations, where a suboperation is associated with a single Element (e.g. single character insertion).

Also unifies the apply_[object]() methods on Content, now apply() works with any Revision, Operation, or Suboperation instance as input.