### PR TITLE
Use google-auth instead of oauth2client credentials

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,17 +15,17 @@ pip install gdocrevisions
 
 ## Example usage
 ```
+from google.oauth2 import service_account
 import gdocrevisions
-from oauth2client.service_account import ServiceAccountCredentials
-
-# Specify the service account credentials file
-CREDENTIAL_FILE = 'my-credentials.json'
-scope = ['https://www.googleapis.com/auth/drive']
-credentials = ServiceAccountCredentials.from_json_keyfile_name(CREDENTIAL_FILE, scope)
 
 # The file id can be found in the URL
 # e.g. https://docs.google.com/document/d/<FILE_ID>
 FILE_ID = 'abcdefg12345'
+
+# Specify the service account credentials file
+CREDENTIAL_FILE = 'my-credentials.json'
+SCOPE = ['https://www.googleapis.com/auth/drive']
+credentials = service_account.Credentials.from_service_account_file(CREDENTIAL_FILE, scopes=SCOPE)
 
 # Initialize a GoogleDoc object instance, which retrieves revision data 
 gdoc = gdocrevisions.GoogleDoc(FILE_ID, credentials)

--- a/gdocrevisions/document.py
+++ b/gdocrevisions/document.py
@@ -1,16 +1,16 @@
-from apiclient.discovery import build
-from httplib2 import Http
 import json
+import pickle
+import logging
+from timeit import default_timer as timer
+from collections import defaultdict
+
+from apiclient.discovery import build
+from google.auth.transport.requests import AuthorizedSession
+
 from revision import Revision
 from session import Session
-import pickle
-from collections import defaultdict
-import copy
-import logging
 from element import EndOfBody
-from oauth2client.client import OAuth2Credentials
-from oauth2client.service_account import ServiceAccountCredentials
-from timeit import default_timer as timer
+
 
 # suppress warnings from google api client library
 logging.getLogger('googleapiclient.discovery_cache').setLevel(logging.ERROR)
@@ -182,21 +182,21 @@ class GoogleDoc(Document):
     Google doc class
     Contains document metadata and revision history
     """
-    def __init__(self, file_id, credentials=None, keyfile=None, metadata=True, **kwargs):
+    def __init__(self, file_id, credentials, metadata=True, **kwargs):
         """
         Create a GoogleDoc instance
         Requires either credentials or keyfile arguments to be specified
 
-        Arguments:
+        Args:
             file_id (str): ID string that can be found in the Google Doc URL
-            credentials (oauth2client.OAuth2Credentals): credentials object
-            keyfile (str): Path to a service account json keyfile
-            metadata (bool): Whether to fetch additional doc-level metadata, e.g. title
+            credentials (google.auth.credentials.Credentials): Credentials object
+            fetch_metadata (bool): Flag indicating whether to fetch additional doc-level metadata, e.g. title
         """
+
         # used by _record_time for recording timing information
         self._times = {}
         # google credentials object instance (oauth2client.OAuth2Credentials or subclass)
-        self.credentials = self._get_credentials(credentials, keyfile)
+        self.credentials = credentials
         # file identifier string from the URL
         self.file_id = file_id
         # dictionary of document metadata via Google API
@@ -209,19 +209,6 @@ class GoogleDoc(Document):
         revisions = self._build_revisions()
         # initialize Document attributes
         super(GoogleDoc, self).__init__(revisions, **kwargs)
-
-
-    def _get_credentials(self, credentials, keyfile):
-        if credentials:
-            if isinstance(credentials, OAuth2Credentials):
-                return credentials
-            else:
-                raise TypeError("Credential object is not a valid OAuth2Credentials object")
-        elif keyfile:
-            scope = ['https://www.googleapis.com/auth/drive']
-            return ServiceAccountCredentials.from_json_keyfile_name(keyfile, scope)
-        else:
-            raise ValueError("No credentials provided")
 
     def _gdrive_api(self):
         """
@@ -260,11 +247,12 @@ class GoogleDoc(Document):
         """
         download json-like data with revision info
         """
-        http_auth = self.credentials.authorize(Http())
         last_revision_id = self._last_revision_id()
         url = self._generate_revision_url(start=1,end=last_revision_id)
-        raw_text = http_auth.request(url)[1][5:]
-        return json.loads(raw_text)
+        response = AuthorizedSession(self.credentials).get(url)
+        response.raise_for_status()
+        data = json.loads(response.text[5:])
+        return data
 
     @timeit
     def _build_revisions(self):

--- a/gdocrevisions/document.py
+++ b/gdocrevisions/document.py
@@ -187,7 +187,7 @@ class GoogleDoc(Document):
         Create a GoogleDoc instance
         Requires either credentials or keyfile arguments to be specified
 
-        Args:
+        Arguments:
             file_id (str): ID string that can be found in the Google Doc URL
             credentials (google.auth.credentials.Credentials): Credentials object
             fetch_metadata (bool): Flag indicating whether to fetch additional doc-level metadata, e.g. title

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,4 @@
-oauth2client
-google-api-python-client
+google-auth==1.4.1
+google-api-python-client==1.6.6
+google-auth-oauthlib==0.2.0
+google-auth-httplib2==0.0.3

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,2 @@
-google-auth==1.4.1
-google-api-python-client==1.6.6
+# additional requirements for tests
 google-auth-oauthlib==0.2.0
-google-auth-httplib2==0.0.3

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(
     install_requires=[
         'google-auth==1.4.1',
         'google-api-python-client==1.6.6',
-        'google-api-python-client==1.6.6',
-        'google-auth-httplib2==0.0.3',
+        'google-auth-httplib2==0.0.3',  # required for using google.auth credentials with google-api-python-client
     ],
 )

--- a/setup.py
+++ b/setup.py
@@ -1,15 +1,18 @@
 from setuptools import setup
 
-setup(name='gdocrevisions',
-      version='0.5.1',
-      description='Package for downloading and analyzing google doc revision history data.',
-      url='https://github.com/harvard-vpal/gdocrevisions',
-      author='Andrew Ang',
-      author_email='andrew_ang@harvard.edu',
-      license='MIT',
-      packages=['gdocrevisions'],
-      install_requires=[
-      	'oauth2client',
-      	'google-api-python-client',
-      ],
+setup(
+    name='gdocrevisions',
+    version='0.5.1',
+    description='Package for downloading and analyzing google doc revision history data.',
+    url='https://github.com/harvard-vpal/gdocrevisions',
+    author='Andrew Ang',
+    author_email='andrew_ang@harvard.edu',
+    license='MIT',
+    packages=['gdocrevisions'],
+    install_requires=[
+        'google-auth==1.4.1',
+        'google-api-python-client==1.6.6',
+        'google-api-python-client==1.6.6',
+        'google-auth-httplib2==0.0.3',
+    ],
 )


### PR DESCRIPTION
[The oauth2client authentication library is depreciated in favor of google-auth.](http://google-auth.readthedocs.io/en/latest/oauth2client-deprecation.html)
* Document init expects a google.auth.credentials.Credentials object instead of the oauth2client credentials object
* Remove support for obtaining user credentials - user should generate appropriate credential (via service account or oauth2) using google-auth or google-auth-oauthlib